### PR TITLE
remove ostruct dependency

### DIFF
--- a/lib/tableless/connection_adapters/dummy_adapter.rb
+++ b/lib/tableless/connection_adapters/dummy_adapter.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
-require 'ostruct'
 
 module Tableless
   class DummyAdapter < ActiveRecord::ConnectionAdapters::AbstractAdapter
+    DbConfig = Struct.new(:adapter)
+
     def initialize(*)
       super
       @schema_cache = Tableless::SchemaCache.new
@@ -17,7 +18,7 @@ module Tableless
     end
 
     def db_config(*)
-      @db_config ||= OpenStruct.new(adapter: :dummy)
+      @db_config ||= DbConfig.new(:dummy)
     end
 
     def with_connection(*)


### PR DESCRIPTION
Tableless currently depends on [ostruct](https://github.com/ruby/ostruct), which triggers deprecation warnings in Ruby 3.4 and above:


> tableless-0.2.2/lib/tableless/connection_adapters/dummy_adapter.rb:2: warning: 
/Users/dolo/.rbenv/versions/3.4.2/lib/ruby/3.4.0/ostruct.rb was loaded from the standard library, 
but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of tableless-0.2.2 to request adding ostruct into its gemspec.

This PR removes the use of ostruct entirely, eliminating the need for the dependency.